### PR TITLE
feat: Add 'Ethics Workgroup' to Discord webhook URLs

### DIFF
--- a/pages/api/discord.ts
+++ b/pages/api/discord.ts
@@ -25,7 +25,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     'Research and Development Guild': process.env.SNET_DISCORD_WEBHOOK_URL,
     'Ambassador Town Hall': process.env.SNET_DISCORD_WEBHOOK_URL,
     'Deep Funding Town Hall': process.env.SNET_DISCORD_WEBHOOK_URL,
-    'One-off Event': process.env.SNET_DISCORD_WEBHOOK_URL
+    'One-off Event': process.env.SNET_DISCORD_WEBHOOK_URL,
+    'Ethics Workgroup': process.env.SNET_DISCORD_WEBHOOK_URL
   };
     
   

--- a/pages/submit-meeting-summary/index.tsx
+++ b/pages/submit-meeting-summary/index.tsx
@@ -86,7 +86,8 @@ const SubmitMeetingSummary: NextPage = () => {
     "Marketing Guild": ["discussionPoints", "decisionItems", "actionItems"],
     "Ambassador Town Hall": ["townHallSummary"],
     "Deep Funding Town Hall": ["townHallSummary"],
-    "One-off Event": ["Narative"]
+    "One-off Event": ["Narative"],
+    "Ethics Workgroup": ["narrative", "decisionItems", "actionItems"]
   };
 
   useEffect(() => {

--- a/utils/updateWorkgroups.js
+++ b/utils/updateWorkgroups.js
@@ -41,7 +41,8 @@ export async function updateWorkgroups(workgroupData) {
     ],
       "tags":1,
       "type":"Custom",
-      "noSummaryGiven": false
+      "noSummaryGiven": false,
+      "canceledSummary": false
       }
   let updates = {...workgroupData, preferred_template}
 


### PR DESCRIPTION
Update the 'pages/api/discord.ts' file to include the 'Ethics Workgroup' in the Discord webhook URLs. This allows messages to be sent to the 'Ethics Workgroup' channel.

Also, update the 'pages/submit-meeting-summary/index.tsx' file to include the 'Ethics Workgroup' in the meeting summary submission form. This ensures that the 'Ethics Workgroup' can submit meeting summaries with the required fields.

Lastly, update the 'utils/updateWorkgroups.js' file to add a new property 'canceledSummary' to the 'preferred_template' object. This property will be used to track if a meeting summary has been canceled.

This commit adds support for the 'Ethics Workgroup' in the Discord integration and meeting summary submission process.